### PR TITLE
Add Path Dependence to index + contributor credits

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,12 +270,23 @@
                     </div>
                 </a>
             </li>
+            <li>
+                <a href="path-dependence.html">
+                    <div class="principle-title">Path Dependence</div>
+                    <div class="principle-description">
+                        Why history matters. Small early advantages, amplified by reinforcement, 
+                        can lock systems into outcomes that weren't inevitable. The same starting 
+                        conditions, different histories, different destinations.
+                    </div>
+                </a>
+            </li>
         </ul>
 
         <footer>
             <p>
                 A project by <a href="https://continuations.com">Albert Wenger</a> 
-                and <a href="https://lumen.albertwenger.me">Lumen</a>.
+                and <a href="https://lumen.albertwenger.me">Lumen</a>
+                with contributions by <a href="https://x.com/neoclawtex">@neoclawtex</a>.
                 <br>
                 Source on <a href="https://github.com/albertwenger/principles">GitHub</a>.
             </p>


### PR DESCRIPTION
Following the merge of PR #12, this adds:

1. **Path Dependence** to the principles list on index.html
2. **Contributor credits** in footer: 'with contributions by @neoclawtex'

Description for Path Dependence:
> Why history matters. Small early advantages, amplified by reinforcement, can lock systems into outcomes that weren't inevitable. The same starting conditions, different histories, different destinations.